### PR TITLE
Add Comment model and associate it with Post

### DIFF
--- a/migrations/02-add-comment-migration.js
+++ b/migrations/02-add-comment-migration.js
@@ -1,0 +1,69 @@
+module.exports = function (migration) {
+    /**
+     * Comment Content Type
+     */
+    const comment = migration.createContentType('comment')
+        .name('Comment')
+        .description('Kullanıcıların blog yazılarına eklediği yorumları içerir.')
+        .displayField('author');
+
+    comment.createField('author')
+        .name('Author')
+        .type('Symbol')
+        .required(true);
+
+    comment.createField('email')
+        .name('Email')
+        .type('Symbol')
+        .required(true);
+
+    comment.createField('content')
+        .name('Content')
+        .type('Text')
+        .required(true);
+
+    comment.createField('post')
+        .name('Post')
+        .type('Link')
+        .linkType('Entry')
+        .required(true)
+        .validations([
+            {
+                linkContentType: ['post'],
+            },
+        ]);
+
+    comment.createField('publishedDate')
+        .name('Published Date')
+        .type('Date')
+        .required(true);
+
+    comment.changeFieldControl('author', 'builtin', 'singleLine');
+    comment.changeFieldControl('email', 'builtin', 'singleLine');
+    comment.changeFieldControl('content', 'builtin', 'multipleLine');
+    comment.changeFieldControl('post', 'builtin', 'entryLinkEditor');
+    comment.changeFieldControl('publishedDate', 'builtin', 'datePicker', {
+        ampm: '24',
+        format: 'dateonly',
+    });
+
+    /**
+     * Post Content Type Update: Add comments field
+     */
+    const post = migration.editContentType('post');
+
+    post.createField('comments')
+        .name('Comments')
+        .type('Array')
+        .items({
+            type: 'Link',
+            linkType: 'Entry',
+            validations: [
+                {
+                    linkContentType: ['comment'],
+                },
+            ],
+        });
+
+    post.changeFieldControl('comments', 'builtin', 'entryLinksEditor');
+};

--- a/src/models/Comment.ts
+++ b/src/models/Comment.ts
@@ -1,0 +1,13 @@
+import { Entry } from "contentful";
+
+import { Post } from "./Post";
+
+export interface CommentFields {
+  author: string;
+  email: string;
+  content: string;
+  post: Entry<Post>;
+  publishedDate: string;
+}
+
+export type Comment = Entry<CommentFields>;

--- a/src/models/Post.ts
+++ b/src/models/Post.ts
@@ -3,6 +3,7 @@ import { Entry, Asset } from "contentful";
 
 import { Author } from "./Author";
 import { Category } from "./Category";
+import { Comment } from "./Comment";
 import { Tag } from "./Tag";
 
 export interface PostFields {
@@ -17,6 +18,7 @@ export interface PostFields {
   publishedDate: string;
   isPopular?: boolean;
   views: number;
+  comments?: Entry<Comment>[];
 }
 
 export type Post = Entry<PostFields>;


### PR DESCRIPTION
Created the Comment model in 'Comment.ts' for user comments on blog posts. Added a migration script to define the Comment content type and updated the Post content type to include a comments field. This allows associating multiple comments with blog posts.