### PR TITLE
Add tag filtering and display to blog posts

### DIFF
--- a/src/app/post/[slug]/page.tsx
+++ b/src/app/post/[slug]/page.tsx
@@ -35,6 +35,7 @@ export default async function Post({ params }: { params: { slug: string } }) {
       content={post.fields.content}
       featuredImage={post.fields.featuredImage}
       publishedDate={post.fields.publishedDate}
+      tags={post.fields.tags}
     />
   );
 }

--- a/src/app/tag/[slug]/page.tsx
+++ b/src/app/tag/[slug]/page.tsx
@@ -1,0 +1,31 @@
+import { Metadata } from "next";
+
+import { TagContainer } from "@/containers/tag/TagContainer";
+import { createMetadata } from "@/lib/createMetadata";
+import { fetchPostsByTag } from "@/services/posts";
+import { fetchTagBySlug } from "@/services/tags";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { slug: string };
+}): Promise<Metadata> {
+  const { slug } = params;
+  const tag = await fetchTagBySlug(slug);
+
+  return createMetadata({
+    title: `${tag?.fields?.name} Posts`,
+    description: `Explore the posts tagged with ${tag?.fields?.name}.`,
+    image: "https://yoursite.com/images/placeholder.png",
+    url: `https://yoursite.com/tag/${slug}`,
+  });
+}
+
+export default async function Tag({ params }: { params: { slug: string } }) {
+  const { slug } = params;
+
+  const tag = await fetchTagBySlug(slug);
+  const posts = tag ? await fetchPostsByTag(tag.sys.id) : [];
+
+  return <TagContainer tag={tag} posts={posts} />;
+}

--- a/src/components/post/PostComponent.module.css
+++ b/src/components/post/PostComponent.module.css
@@ -20,3 +20,18 @@
   line-height: 1.6;
   margin: 2rem 0;
 }
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.tag {
+  background-color: #007bff;
+  border-radius: 5px;
+  color: white;
+  font-size: 0.875rem;
+  padding: 0.25rem 0.5rem;
+}

--- a/src/components/post/PostComponent.tsx
+++ b/src/components/post/PostComponent.tsx
@@ -9,10 +9,11 @@ interface PostProps {
   content: any;
   featuredImage?: any;
   publishedDate: string;
+  tags?: any;
 }
 
 export const PostComponent = (props: PostProps) => {
-  const { title, content, featuredImage, publishedDate } = props;
+  const { title, content, featuredImage, publishedDate, tags } = props;
   const parsedImage = parseContentfulContentImage(featuredImage);
 
   return (
@@ -27,6 +28,13 @@ export const PostComponent = (props: PostProps) => {
         />
       )}
       <div className={styles.content}>{documentToReactComponents(content)}</div>
+      <div className={styles.tags}>
+        {tags?.map((tag: any) => (
+          <span key={tag.sys.id} className={styles.tag}>
+            {tag.fields.name}
+          </span>
+        ))}
+      </div>
     </div>
   );
 };

--- a/src/containers/home/HomeContainer.module.css
+++ b/src/containers/home/HomeContainer.module.css
@@ -154,3 +154,10 @@
   display: inline-block;
   padding: 0.5rem;
 }
+
+.tagUrl {
+  color: #5a5a5a;
+  font-size: 14px;
+  font-weight: 400;
+  text-decoration: none;
+}

--- a/src/containers/home/HomeContainer.tsx
+++ b/src/containers/home/HomeContainer.tsx
@@ -78,7 +78,12 @@ export default function HomeContainer({
           <ul className={styles.tagsListContainer}>
             {tags.map((tag) => (
               <li key={tag.sys.id} className={styles.tag}>
-                {tag.fields.name}
+                <Link
+                  href={`/tag/${tag.fields.slug}`}
+                  className={styles.tagUrl}
+                >
+                  {tag.fields.name}
+                </Link>
               </li>
             ))}
           </ul>

--- a/src/containers/tag/TagContainer.module.css
+++ b/src/containers/tag/TagContainer.module.css
@@ -1,0 +1,24 @@
+.tag {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding-bottom: 1.5rem;
+}
+
+.tagTitle {
+  color: #5a5a5a;
+  font-size: 2rem;
+  font-weight: 300;
+}
+
+.blogPosts {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+@media screen and (width <= 768px){
+  .tagTitle {
+    font-size: 1.5rem;
+  }
+}

--- a/src/containers/tag/TagContainer.tsx
+++ b/src/containers/tag/TagContainer.tsx
@@ -1,0 +1,40 @@
+import { Entry } from "contentful";
+
+import { PostPreview } from "@/components/post-preview/PostPreview";
+import { parseContentfulContentImage } from "@/lib/parseContentfulImageAsset";
+import { CategorySkeleton } from "@/models/Category";
+import { BlogPostSkeleton } from "@/models/Post";
+
+import styles from "./TagContainer.module.css";
+
+interface TagContainerProps {
+  category: Entry<CategorySkeleton> | null;
+  posts: Array<Entry<BlogPostSkeleton, undefined, string>>;
+}
+
+export const TagContainer = ({ tag, posts }: TagContainerProps) => {
+  if (!tag) {
+    return null;
+  }
+
+  return (
+    <div className={styles.tag}>
+      <h1 className={styles.tagTitle}>{tag.fields.name as string}</h1>
+      <div className={styles.blogPosts}>
+        {posts.map((post) => (
+          <PostPreview
+            key={post.fields.slug}
+            title={post.fields.title}
+            date={post.fields.publishedDate}
+            summary={post.fields.excerpt}
+            imageUrl={
+              parseContentfulContentImage(post.fields.featuredImage)?.src
+            }
+            slug={post.fields.slug}
+          />
+        ))}
+      </div>
+      {posts.length === 0 && <p>No posts found in this category!</p>}
+    </div>
+  );
+};

--- a/src/services/posts.ts
+++ b/src/services/posts.ts
@@ -43,3 +43,14 @@ export const fetchPostBySlug = async (slug: string) => {
 
   return entries.items[0];
 };
+
+export const fetchPostsByTag = async (tagId: string) => {
+  const entries = await client.getEntries<BlogPostSkeleton>({
+    content_type: "post",
+    order: ["-fields.publishedDate"],
+    limit: 10,
+    "fields.tags.sys.id": tagId, // Assuming 'tags' field contains the tag references
+  });
+
+  return entries.items || [];
+};

--- a/src/services/tags.ts
+++ b/src/services/tags.ts
@@ -11,3 +11,17 @@ export const fetchLatestTags = async () => {
 
   return entries.items || [];
 };
+
+export const fetchTagBySlug = async (slug: string) => {
+  const entries = await client.getEntries({
+    content_type: "tag",
+    "fields.slug": slug,
+    limit: 1,
+  });
+
+  if (!entries.items.length) {
+    return null;
+  }
+
+  return entries.items[0];
+};


### PR DESCRIPTION
Implemented a feature to filter posts by tags and display tags for each post. Added a new page to show posts by tag, updated CSS for tag styling, and modified components to support tags. This enhances navigation and user engagement.